### PR TITLE
Master

### DIFF
--- a/Assets/Coffee/UIExtensions/SoftMaskForUGUI/SoftMask.cginc
+++ b/Assets/Coffee/UIExtensions/SoftMaskForUGUI/SoftMask.cginc
@@ -23,8 +23,8 @@ half SoftMask(float4 clipPos)
 {
 	half2 view = clipPos.xy/_ScreenParams.xy;
 	#if UNITY_UV_STARTS_AT_TOP
-        view.y = 1.0 - view.y;
-    #endif
+		view.y = 1.0 - view.y;
+	#endif
 	
 	half alpha =
 		lerp(1, tex2D(_SoftMaskTex, view).a, step(15, _Stencil))

--- a/Assets/Coffee/UIExtensions/SoftMaskForUGUI/SoftMask.cginc
+++ b/Assets/Coffee/UIExtensions/SoftMaskForUGUI/SoftMask.cginc
@@ -22,6 +22,10 @@ fixed Approximately(float4x4 a, float4x4 b)
 half SoftMask(float4 clipPos)
 {
 	half2 view = clipPos.xy/_ScreenParams.xy;
+	#if UNITY_UV_STARTS_AT_TOP
+        view.y = 1.0 - view.y;
+    #endif
+	
 	half alpha =
 		lerp(1, tex2D(_SoftMaskTex, view).a, step(15, _Stencil))
 		* lerp(1, tex2D(_SoftMaskTex, view).b, step(7, _Stencil))


### PR DESCRIPTION
![Flipped Mask Problem](https://user-images.githubusercontent.com/4518980/51033968-5b79b200-15a5-11e9-929c-2db6a8b40480.png)

On android (and any platform where uv starts at top) there is a problem with the mask texture as seen in the image above. The red star is the mask texture, but it is flipped for the soft maskable image. This PR fixes the problem with a platform dependant compilation.