### PR TITLE
fixed #52 where click events were not detected due to the y axis beeing inverted on some graphics apis

### DIFF
--- a/Assets/Coffee/UIExtensions/SoftMaskForUGUI/Scripts/SoftMask.cs
+++ b/Assets/Coffee/UIExtensions/SoftMaskForUGUI/Scripts/SoftMask.cs
@@ -259,7 +259,16 @@ namespace Coffee.UIExtensions
 			}
 
 			int x = (int)((softMaskBuffer.width - 1) * Mathf.Clamp01(sp.x / Screen.width));
-			int y = (int)((softMaskBuffer.height - 1) * Mathf.Clamp01(sp.y / Screen.height));
+			int y = (int)((softMaskBuffer.height - 1) * (Mathf.Clamp01(sp.y / Screen.height)));
+
+			if ((SystemInfo.graphicsDeviceType == GraphicsDeviceType.Direct3D11) ||
+				(SystemInfo.graphicsDeviceType == GraphicsDeviceType.PlayStation4) ||
+				(SystemInfo.graphicsDeviceType == GraphicsDeviceType.Vulkan) ||
+				(SystemInfo.graphicsDeviceType == GraphicsDeviceType.Switch))
+			{
+				y = (int)((softMaskBuffer.height - 1) * (1 - Mathf.Clamp01(sp.y / Screen.height)));
+			}
+
 			return 0.5f < GetPixelValue(x, y, interactions);
 		}
 


### PR DESCRIPTION
This should fix the issue, however it was only tested on Android, iOS, Windows and Linux (should be tested on other platforms too).
Weirdly enough the fix mustn't be applied on the Metal platform (iOS) despite having the y axis inverted (see here: https://docs.unity3d.com/Manual/SL-PlatformDifferences.html under Render Texture coordinates; maybe this case is handled elsewhere).