### PR TITLE
fix: fixed shader compilation in some platforms

### DIFF
--- a/Shaders/SoftMask.cginc
+++ b/Shaders/SoftMask.cginc
@@ -9,7 +9,14 @@ half4 _MaskInteraction;
 
 fixed Approximately(float4x4 a, float4x4 b)
 {
-	float4x4 d = abs(a - b);
+	float4x4 d = a - b;
+	d = float4x4(
+			abs(d[0]),
+			abs(d[1]),
+			abs(d[2]),
+			abs(d[3])
+		);
+		
 	return step(
 		max(d._m00,max(d._m01,max(d._m02,max(d._m03,
 		max(d._m10,max(d._m11,max(d._m12,max(d._m13,


### PR DESCRIPTION
The overload abs(float4x4, float4x4) is not present in some platforms
supported by Unity
Decomposing the operation fixes the problem

---
name: Pull Request
about: Create a pull request
title: ''
assignees: mob-sakai

---

**NOTE: Create a pull request to merge into `develop` branch**
