### PR TITLE
Fixed a major performance regression where if you had a lot of softma…

### DIFF
--- a/Scripts/SoftMaskable.cs
+++ b/Scripts/SoftMaskable.cs
@@ -248,6 +248,8 @@ namespace Coffee.UISoftMask
 #if UNITY_EDITOR
                 s_GameVPId = Shader.PropertyToID("_GameVP");
                 s_GameTVPId = Shader.PropertyToID("_GameTVP");
+                UnityEditor.SceneView.beforeSceneGui -= SceneView_beforeSceneGui; // For safety
+                UnityEditor.SceneView.beforeSceneGui += SceneView_beforeSceneGui;
 #endif
             }
 
@@ -269,13 +271,16 @@ namespace Coffee.UISoftMask
 
             MaterialCache.Unregister(_effectMaterialHash);
             _effectMaterialHash = k_InvalidHash;
+#if UNITY_EDITOR
+            UnityEditor.SceneView.beforeSceneGui -= SceneView_beforeSceneGui;
+#endif
         }
 
 #if UNITY_EDITOR
         private void UpdateMaterialForSceneView(Material mat)
         {
             if(!mat || !graphic || !graphic.canvas || !mat.shader || !mat.shader.name.EndsWith(" (SoftMaskable)")) return;
-
+            Debug.Log("UpdateMaterialForSceneView");
             // Set view and projection matrices.
             Profiler.BeginSample("Set view and projection matrices");
             var c = graphic.canvas.rootCanvas;
@@ -301,9 +306,12 @@ namespace Coffee.UISoftMask
             Profiler.EndSample();
         }
 
-        private void LateUpdate()
+        private void SceneView_beforeSceneGui(UnityEditor.SceneView obj)
         {
-            UpdateMaterialForSceneView(modifiedMaterial);
+            
+            var parentCanvas = GetComponentInParent<Canvas>(); // Don't think we can cache this in case this go is moved to another parent
+            if (parentCanvas != null && parentCanvas.enabled) // Only do this expensive call if the UI element is active
+                UpdateMaterialForSceneView(modifiedMaterial);
         }
 
 

--- a/Scripts/SoftMaskable.cs
+++ b/Scripts/SoftMaskable.cs
@@ -280,7 +280,7 @@ namespace Coffee.UISoftMask
         private void UpdateMaterialForSceneView(Material mat)
         {
             if(!mat || !graphic || !graphic.canvas || !mat.shader || !mat.shader.name.EndsWith(" (SoftMaskable)")) return;
-            Debug.Log("UpdateMaterialForSceneView");
+            
             // Set view and projection matrices.
             Profiler.BeginSample("Set view and projection matrices");
             var c = graphic.canvas.rootCanvas;


### PR DESCRIPTION
Fixed a major performance regression where if you had a lot of softmaskable components (even if the parent canvas was in-active) it would eat over 20ms doing a certain editor-only function.
---
name: Pull Request
about: Create a pull request
title: 'Fixed performance regression'
assignees: mob-sakai
